### PR TITLE
fix: remove expired batches time comparison

### DIFF
--- a/example/src/main.tmpl.mo
+++ b/example/src/main.tmpl.mo
@@ -154,7 +154,7 @@ shared({caller = owner}) actor class Assets() : async AssetStorage.Self = {
 
                 // Remove expired batches and chunks.
                 for ((k, b) in state.batches.entries()) {
-                    if (b.expires_at > now) state.batches.delete(k);
+                    if (now > b.expires_at) state.batches.delete(k);
                 };
                 for ((k, c) in state.chunks.entries()) {
                     switch (state.batches.get(c.batch_id)) {


### PR DESCRIPTION
I did not ran the code and not 100% sure but, shouldn't the expiration time to clear batches be checked the opposite way around?

Is:

```
if (b.expires_at > now) state.batches.delete(k);
```

This PR suggestion:

```
if (now > b.expires_at) state.batches.delete(k);
```